### PR TITLE
Cap endorsement array to prevent DoS via unbounded loop

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,4 +1,10 @@
 {
+  "lib/forge-std": {
+    "rev": "1801b0541f4fda118a10798fd3486bb7051c5dd6"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "fcbae5394ae8ad52d8e580a3477db99814b9d565"
+  },
   "lib\\forge-std": {
     "tag": {
       "name": "v1.14.0",

--- a/src/IdentityToken.sol
+++ b/src/IdentityToken.sol
@@ -11,6 +11,8 @@ import { IIdentityToken } from "./interfaces/IIdentityToken.sol";
 contract IdentityToken is ERC721, IIdentityToken {
     error NonTransferable();
 
+    uint256 public constant MAX_ENDORSEMENTS = 50;
+
     uint256 private _nextTokenId = 1;
 
     // wallet => tokenId (enforce one identity per wallet)
@@ -160,6 +162,8 @@ contract IdentityToken is ERC721, IIdentityToken {
         if (_ownerOf(toTokenId) == address(0)) revert Errors.TargetInvalid();
 
         DataTypes.Endorsement[] storage list = endorsements[toTokenId];
+
+        if (list.length >= MAX_ENDORSEMENTS) revert Errors.MaxEndorsementsReached();
 
         // prevent duplicate active endorsements
         for (uint256 i = 0; i < list.length; i++) {

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -16,4 +16,5 @@ library Errors {
     error AlreadyHasIdentity();
     error DuplicateEndorsement();
     error ArrayLengthMismatch();
+    error MaxEndorsementsReached();
 }

--- a/test/IdentityToken.t.sol
+++ b/test/IdentityToken.t.sol
@@ -529,4 +529,69 @@ contract IdentityTokenTest is Test {
 
         assertTrue(identityToken.isExpired(tokenId));
     }
+
+    // -------------------------------------------------------------------------
+    // MAX_ENDORSEMENTS (DoS prevention)
+    // -------------------------------------------------------------------------
+
+    /// @notice The 50th endorsement (at the limit) must succeed.
+    function test_Endorse_AtMaxLimit() public {
+        // Target identity that will receive all endorsements
+        vm.prank(alice);
+        uint256 targetId = identityToken.mint();
+
+        bytes32 connectionType = keccak256(abi.encodePacked("Colleague"));
+        uint256 maxEndorsements = identityToken.MAX_ENDORSEMENTS(); // 50
+
+        // Mint 50 unique endorsers and have each endorse the target
+        for (uint256 i = 0; i < maxEndorsements; i++) {
+            address endorser = address(uint160(1000 + i));
+            vm.prank(endorser);
+            uint256 endorserId = identityToken.mint();
+
+            vm.prank(endorser);
+            identityToken.endorse(endorserId, targetId, connectionType, 0);
+        }
+
+        // Verify the target has exactly MAX_ENDORSEMENTS endorsements
+        DataTypes.Identity memory identity = identityToken.getIdentity(targetId);
+        assertEq(identity.endorsementCount, maxEndorsements);
+
+        // Verify the target is considered verified
+        assertTrue(identityToken.isVerified(targetId));
+    }
+
+    /// @notice The 51st endorsement must revert with MaxEndorsementsReached.
+    function test_RevertIf_MaxEndorsementsReached() public {
+        // Target identity that will receive all endorsements
+        vm.prank(alice);
+        uint256 targetId = identityToken.mint();
+
+        bytes32 connectionType = keccak256(abi.encodePacked("Colleague"));
+        uint256 maxEndorsements = identityToken.MAX_ENDORSEMENTS(); // 50
+
+        // Fill up to the maximum
+        for (uint256 i = 0; i < maxEndorsements; i++) {
+            address endorser = address(uint160(2000 + i));
+            vm.prank(endorser);
+            uint256 endorserId = identityToken.mint();
+
+            vm.prank(endorser);
+            identityToken.endorse(endorserId, targetId, connectionType, 0);
+        }
+
+        // The 51st endorsement must revert
+        address extraEndorser = address(uint160(9999));
+        vm.prank(extraEndorser);
+        uint256 extraId = identityToken.mint();
+
+        vm.prank(extraEndorser);
+        vm.expectRevert(Errors.MaxEndorsementsReached.selector);
+        identityToken.endorse(extraId, targetId, connectionType, 0);
+    }
+
+    /// @notice MAX_ENDORSEMENTS constant is exposed and equals 50.
+    function test_MAX_ENDORSEMENTS_Constant() public view {
+        assertEq(identityToken.MAX_ENDORSEMENTS(), 50);
+    }
 }


### PR DESCRIPTION
The `endorse()` function in `src/IdentityToken.sol` iterates over the entire endorsements array for duplicate checking, and `isVerified()` does the same to tally active endorsements. Since nothing previously limited how large that array could grow, a malicious actor could keep piling on endorsements until the gas cost of iterating made both functions revert — effectively bricking verification for the targeted token.

This change introduces a `MAX_ENDORSEMENTS` constant (set to 50) at the contract level and adds a single guard at the top of `endorse()`: `if (list.length >= MAX_ENDORSEMENTS) revert Errors.MaxEndorsementsReached();`. The cap is checked before the duplicate-detection loop runs, so gas waste is minimal when the limit is hit. A dedicated `MaxEndorsementsReached` custom error was added to `src/libraries/Errors.sol` to give callers a clear, ABI-decodable signal rather than an opaque out-of-gas failure. The constant is `public`, so off-chain clients can read it without hard-coding the value.

The design intentionally keeps the existing storage layout and loop logic untouched — no migration, no new mappings — because 50 iterations is well within a single block's gas budget on any EVM-compatible chain this contract targets. Three new Foundry tests in `test/IdentityToken.t.sol` cover the boundary: `test_Endorse_AtMaxLimit` confirms the 50th endorsement succeeds and the token is verified, `test_RevertIf_MaxEndorsementsReached` proves the 51st endorsement reverts with the correct selector, and `test_MAX_ENDORSEMENTS_Constant` asserts the public getter returns 50. All three pass locally with `forge test` and the full existing suite remains green.

Closes https://github.com/StabilityNexus/IdentityTokens-EVM-Contracts/issues/68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a maximum endorsement cap of 50 per identity token. Attempts to add endorsements beyond this limit will be blocked with an error notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->