### PR TITLE
Add revoke endorsement logic

### DIFF
--- a/src/IdentityToken.sol
+++ b/src/IdentityToken.sol
@@ -185,6 +185,28 @@ contract IdentityToken is ERC721, IIdentityToken {
         emit Events.EndorsementGiven(fromTokenId, toTokenId, connectionType, validUntil);
     }
 
+    /**
+     * @dev Allows the original endorser to revoke a previously given endorsement.
+     * @param targetTokenId The token that received the endorsement.
+     * @param index         The position of the endorsement in endorsements[targetTokenId].
+     */
+    function revokeEndorsement(uint256 targetTokenId, uint256 index) external {
+        DataTypes.Endorsement[] storage list = endorsements[targetTokenId];
+
+        if (index >= list.length) revert Errors.IndexOutOfBounds();
+
+        DataTypes.Endorsement storage e = list[index];
+
+        uint256 callerTokenId = ownerToTokenId[msg.sender];
+        if (callerTokenId == 0 || e.endorserTokenId != callerTokenId) revert Errors.NotEndorser();
+
+        if (e.revokedAt != 0) revert Errors.AlreadyRevoked();
+
+        e.revokedAt = block.timestamp;
+
+        emit Events.EndorsementRevoked(e.endorserTokenId, targetTokenId, index);
+    }
+
     // -------------------------------------------------------------------------
     // Internal
     // -------------------------------------------------------------------------

--- a/test/IdentityToken.t.sol
+++ b/test/IdentityToken.t.sol
@@ -392,6 +392,158 @@ contract IdentityTokenTest is Test {
         vm.expectRevert(Errors.IdentityCompromised.selector);
         identityToken.deleteAttribute(tokenId, "email");
     }
+    // -------------------------------------------------------------------------
+    // Endorsement Revocation
+    // -------------------------------------------------------------------------
+
+    function test_RevokeEndorsement_SetsRevokedAt() public {
+        vm.prank(alice);
+        uint256 aliceId = identityToken.mint();
+
+        vm.prank(bob);
+        uint256 bobId = identityToken.mint();
+
+        bytes32 connectionType = keccak256(abi.encodePacked("Colleague"));
+
+        vm.prank(alice);
+        identityToken.endorse(aliceId, bobId, connectionType, 0);
+
+        vm.prank(alice);
+        identityToken.revokeEndorsement(bobId, 0);
+
+        (, , , , uint256 revokedAt) = identityToken.endorsements(bobId, 0);
+        assertGt(revokedAt, 0);
+    }
+
+    function test_RevokeEndorsement_EmitsEvent() public {
+        vm.prank(alice);
+        uint256 aliceId = identityToken.mint();
+
+        vm.prank(bob);
+        uint256 bobId = identityToken.mint();
+
+        bytes32 connectionType = keccak256(abi.encodePacked("Colleague"));
+
+        vm.prank(alice);
+        identityToken.endorse(aliceId, bobId, connectionType, 0);
+
+        vm.prank(alice);
+        vm.expectEmit(true, true, false, true);
+        emit Events.EndorsementRevoked(aliceId, bobId, 0);
+        identityToken.revokeEndorsement(bobId, 0);
+    }
+
+    function test_RevokeEndorsement_MakesEndorsementInactive() public {
+        vm.prank(alice);
+        uint256 aliceId = identityToken.mint();
+
+        vm.prank(bob);
+        uint256 bobId = identityToken.mint();
+
+        bytes32 connectionType = keccak256(abi.encodePacked("Colleague"));
+
+        vm.prank(alice);
+        identityToken.endorse(aliceId, bobId, connectionType, 0);
+
+        assertTrue(identityToken.isVerified(bobId));
+
+        vm.prank(alice);
+        identityToken.revokeEndorsement(bobId, 0);
+
+        assertFalse(identityToken.isVerified(bobId));
+    }
+
+    function test_RevokeEndorsement_AllowsReEndorseAfterRevocation() public {
+        vm.prank(alice);
+        uint256 aliceId = identityToken.mint();
+
+        vm.prank(bob);
+        uint256 bobId = identityToken.mint();
+
+        bytes32 connectionType = keccak256(abi.encodePacked("Colleague"));
+
+        vm.prank(alice);
+        identityToken.endorse(aliceId, bobId, connectionType, 0);
+
+        vm.prank(alice);
+        identityToken.revokeEndorsement(bobId, 0);
+
+        // Re-endorsing should succeed because the previous one is revoked
+        vm.prank(alice);
+        identityToken.endorse(aliceId, bobId, connectionType, 0);
+
+        (, , , , uint256 revokedAt) = identityToken.endorsements(bobId, 1);
+        assertEq(revokedAt, 0);
+    }
+
+    function test_RevertIf_RevokeEndorsement_NotEndorser() public {
+        vm.prank(alice);
+        uint256 aliceId = identityToken.mint();
+
+        vm.prank(bob);
+        uint256 bobId = identityToken.mint();
+
+        bytes32 connectionType = keccak256(abi.encodePacked("Colleague"));
+
+        vm.prank(alice);
+        identityToken.endorse(aliceId, bobId, connectionType, 0);
+
+        // Bob tries to revoke Alice's endorsement
+        vm.prank(bob);
+        vm.expectRevert(Errors.NotEndorser.selector);
+        identityToken.revokeEndorsement(bobId, 0);
+    }
+
+    function test_RevertIf_RevokeEndorsement_AlreadyRevoked() public {
+        vm.prank(alice);
+        uint256 aliceId = identityToken.mint();
+
+        vm.prank(bob);
+        uint256 bobId = identityToken.mint();
+
+        bytes32 connectionType = keccak256(abi.encodePacked("Colleague"));
+
+        vm.prank(alice);
+        identityToken.endorse(aliceId, bobId, connectionType, 0);
+
+        vm.prank(alice);
+        identityToken.revokeEndorsement(bobId, 0);
+
+        vm.prank(alice);
+        vm.expectRevert(Errors.AlreadyRevoked.selector);
+        identityToken.revokeEndorsement(bobId, 0);
+    }
+
+    function test_RevertIf_RevokeEndorsement_IndexOutOfBounds() public {
+        vm.prank(alice);
+        identityToken.mint();
+
+        vm.prank(bob);
+        uint256 bobId = identityToken.mint();
+
+        vm.prank(alice);
+        vm.expectRevert(Errors.IndexOutOfBounds.selector);
+        identityToken.revokeEndorsement(bobId, 0);
+    }
+
+    function test_RevertIf_RevokeEndorsement_CallerHasNoToken() public {
+        vm.prank(alice);
+        uint256 aliceId = identityToken.mint();
+
+        vm.prank(bob);
+        uint256 bobId = identityToken.mint();
+
+        bytes32 connectionType = keccak256(abi.encodePacked("Colleague"));
+
+        vm.prank(alice);
+        identityToken.endorse(aliceId, bobId, connectionType, 0);
+
+        address stranger = address(0x3);
+        vm.prank(stranger);
+        vm.expectRevert(Errors.NotEndorser.selector);
+        identityToken.revokeEndorsement(bobId, 0);
+    }
+
     // --- hasIdentity ---
 
     function test_HasIdentity_True() public {


### PR DESCRIPTION
###  Addressed Issues:

Fixes #49 


###  Screenshots/Recordings:

<img width="429" height="109" alt="image" src="https://github.com/user-attachments/assets/aeb1c848-63b7-45f3-8964-4a7b71b78a37" />


###  Additional Notes:
<!-- What issue does this PR close? -->

This PR implements the missing **endorsement revocation logic**, enabling identities to withdraw previously given endorsements.

While the `Endorsement` struct already included a `revokedAt` field and the `EndorsementRevoked` event was defined, there was no functional mechanism connecting them. This change completes that flow by introducing a revocation function with proper authorization, validation, and state updates.

Revoked endorsements are now correctly treated as inactive, allowing future re-endorsements without conflict.

## 🔧 Changes Made

* Added `revokeEndorsement(uint256 targetTokenId, uint256 index)` to `IdentityToken.sol`

  * Validates index bounds using `Errors.IndexOutOfBounds`
  * Ensures only the original endorser (via `ownerToTokenId`) can revoke
  * Prevents double revocation using `Errors.AlreadyRevoked`
  * Updates `revokedAt` with `block.timestamp`
  * Emits `EndorsementRevoked` event

* Ensured revoked endorsements are treated as inactive in existing logic (via `revokedAt == 0` checks)

* Added comprehensive test coverage in `IdentityToken.t.sol`:

  *  Successful revocation updates state
  *  Event emission verification
  *  Revoked endorsements become inactive
  *  Re-endorsement works after revocation
  
## Testing

All new and existing tests pass.
Test cases cover both expected flows and edge cases to ensure correctness and safety.

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now revoke previously given endorsements
  * Revoked endorsements automatically update verification status
  * Support for re-endorsement after revocation with proper validation

* **Tests**
  * Added comprehensive test coverage for endorsement revocation scenarios
  * Included validation for error cases and state transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->