### PR TITLE
Add assertion to test_DeleteAttribute_Twice_DoesNotRevert for explicit state verification

### DIFF
--- a/test/IdentityToken.t.sol
+++ b/test/IdentityToken.t.sol
@@ -358,6 +358,10 @@ contract IdentityTokenTest is Test {
 
         vm.prank(alice);
         identityToken.deleteAttribute(tokenId, "email");
+
+        bytes32 keyHash = keccak256(abi.encodePacked("email"));
+        bytes memory value = identityToken.attributes(tokenId, keyHash);
+        assertEq(value.length, 0);
     }
 
     function test_DeleteAttribute_ThenReSet() public {

--- a/test/IdentityToken.t.sol
+++ b/test/IdentityToken.t.sol
@@ -358,9 +358,7 @@ contract IdentityTokenTest is Test {
 
         vm.prank(alice);
         identityToken.deleteAttribute(tokenId, "email");
-
-        bytes32 keyHash = keccak256(abi.encodePacked("email"));
-        bytes memory value = identityToken.attributes(tokenId, keyHash);
+        bytes memory value = identityToken.attributes(tokenId, Schema.EMAIL);
         assertEq(value.length, 0);
     }
 


### PR DESCRIPTION
###  Addressed Issues:
Closes #66 
The test test_DeleteAttribute_Twice_DoesNotRevert in test/IdentityToken.t.sol currently only verifies that calling deleteAttribute twice does not revert. It does not assert the final state of the attribute after the second delete, leaving the expected post-condition implicit.

Suggested Change
Add an assertion after the second deleteAttribute call to explicitly verify that the attribute value is empty:

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened test coverage for attribute deletion operations to ensure proper state validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->