### PR TITLE
fix: invalidate compromised endorsers in isVerified

### DIFF
--- a/src/IdentityToken.sol
+++ b/src/IdentityToken.sol
@@ -242,7 +242,9 @@ contract IdentityToken is ERC721, IIdentityToken {
         DataTypes.Endorsement[] storage list = endorsements[tokenId];
         for (uint256 i = 0; i < list.length; i++) {
             DataTypes.Endorsement storage e = list[i];
-            bool active = e.revokedAt == 0 && (e.validUntil == 0 || e.validUntil >= block.timestamp) && !identityStates[e.endorserTokenId].isCompromised;
+            bool active = e.revokedAt == 0 &&
+                (e.validUntil == 0 || e.validUntil >= block.timestamp) &&
+                !identityStates[e.endorserTokenId].isCompromised;
             if (active) return true;
         }
         return false;

--- a/src/IdentityToken.sol
+++ b/src/IdentityToken.sol
@@ -242,7 +242,7 @@ contract IdentityToken is ERC721, IIdentityToken {
         DataTypes.Endorsement[] storage list = endorsements[tokenId];
         for (uint256 i = 0; i < list.length; i++) {
             DataTypes.Endorsement storage e = list[i];
-            bool active = e.revokedAt == 0 && (e.validUntil == 0 || e.validUntil >= block.timestamp);
+            bool active = e.revokedAt == 0 && (e.validUntil == 0 || e.validUntil >= block.timestamp) && !identityStates[e.endorserTokenId].isCompromised;
             if (active) return true;
         }
         return false;

--- a/test/IdentityToken.t.sol
+++ b/test/IdentityToken.t.sol
@@ -478,6 +478,24 @@ contract IdentityTokenTest is Test {
         assertTrue(identityToken.isVerified(bobId));
     }
 
+    function test_IsVerified_FalseIfEndorserCompromised() public {
+        vm.prank(alice);
+        uint256 aliceId = identityToken.mint();
+
+        vm.prank(bob);
+        uint256 bobId = identityToken.mint();
+
+        bytes32 connectionType = keccak256(abi.encodePacked("Colleague"));
+        vm.prank(alice);
+        identityToken.endorse(aliceId, bobId, connectionType, 0);
+
+        stdstore.target(address(identityToken)).sig("identityStates(uint256)").with_key(aliceId).depth(0).checked_write(
+            true
+        );
+
+        assertFalse(identityToken.isVerified(bobId));
+    }
+
     function test_IsVerified_FalseWithExpiredEndorsement() public {
         vm.prank(alice);
         uint256 aliceId = identityToken.mint();


### PR DESCRIPTION
###  Addressed Issues:

Fixes #67 

Updated the `active` check in `src/IdentityToken.sol` (`isVerified`) to also require:
`!identityStates[e.endorserTokenId].isCompromised`

New logic:
`bool active = e.revokedAt == 0 && (e.validUntil == 0 || e.validUntil >= block.timestamp) && !identityStates[e.endorserTokenId].isCompromised;`

#### Tests
Added one new test in `test/IdentityToken.t.sol`:
- `test_IsVerified_FalseIfEndorserCompromised()`

Test flow:
1. Mint endorser + target identities
2. Create endorsement
3. Mark endorser as compromised via `stdstore`
4. Assert `isVerified(target)` returns `false`

###  Screenshots/Recordings:

<img width="869" height="114" alt="Screenshot 2026-03-26 193237" src="https://github.com/user-attachments/assets/d8dc7eb2-2523-4f95-8100-87b9d492235c" />



###  Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->
#### Security Impact
Prevents compromised identities from continuing to confer trust via existing endorsements, closing a trust-graph bypass risk.

#### Gas / Performance
`isVerified` now performs one additional storage read per endorsement candidate (`identityStates[endorserTokenId].isCompromised`).  
This is an intentional security tradeoff; short-circuiting still avoids that read for already revoked/expired endorsements.

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verification now properly validates that an endorser's identity is not compromised, in addition to checking standard endorsement validity conditions like revocation status and expiration time.

* **Tests**
  * Added test coverage to verify that endorsements are correctly invalidated when the endorser's identity is marked as compromised, strengthening overall identity security validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->